### PR TITLE
refactor global scope only logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,16 @@
 module.exports = function (context) {
   var message = 'Imported module variable name not capitalized.';
   var globalScopeOnly = context.options[0] === 'global-scope-only';
+  var VALID_TOP_LEVEL_PARENTS = [
+    'AssignmentExpression',
+    'VariableDeclarator',
+    'MemberExpression',
+    'ExpressionStatement',
+    'CallExpression',
+    'ConditionalExpression',
+    'Program',
+    'VariableDeclaration'
+  ];
 
 
   function isCapitalized (name) {
@@ -19,8 +29,15 @@ module.exports = function (context) {
   }
 
 
+  function atTopLevel () {
+    return context.getAncestors().every(function (parent) {
+      return VALID_TOP_LEVEL_PARENTS.indexOf(parent.type) > -1;
+    });
+  }
+
+
   function check (node) {
-    if (globalScopeOnly === true && context.getScope().type !== 'global') {
+    if (globalScopeOnly === true && atTopLevel() === false) {
       return;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -61,7 +61,6 @@ describe('ESLint Rule', function () {
       'var poop; poop = require("poop");'
     ];
 
-
     ruleTester.run(HapiCapitalizeModules.esLintRuleName, HapiCapitalizeModules, {
       valid: valid.map(function (code) {
         return {
@@ -72,6 +71,27 @@ describe('ESLint Rule', function () {
       invalid: invalid.map(function (code) {
         return {
           code: code,
+          options: ['global-scope-only'],
+          errors: [{message: 'Imported module variable name not capitalized.'}]
+        };
+      })
+    });
+    done();
+  });
+
+  it('global-scope-only works in the presense of ES6 modules', function (done) {
+    var ruleTester = new RuleTester();
+    var invalid = [
+      'hapi = require("hapi");',
+      'var poop; poop = require("poop");'
+    ];
+
+    ruleTester.run(HapiCapitalizeModules.esLintRuleName, HapiCapitalizeModules, {
+      valid: [],
+      invalid: invalid.map(function (code) {
+        return {
+          code: code,
+          ecmaFeatures: {modules: true},
           options: ['global-scope-only'],
           errors: [{message: 'Imported module variable name not capitalized.'}]
         };


### PR DESCRIPTION
The existing logic that determined if a `require()` was at the top level scope broke between ESLint v1.3.1 and [v1.4.0](http://eslint.org/blog/2015/09/eslint-v1.4.0-released/) (likely https://github.com/eslint/eslint/issues/3700). This PR refactors that logic, using ESLint's [global-require rule](https://github.com/eslint/eslint/blob/master/lib/rules/global-require.js) as a template.
